### PR TITLE
Feat/#3

### DIFF
--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshToken.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshToken.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 
 @Entity
 @Getter
@@ -25,12 +26,12 @@ public class RefreshToken {
     private String refreshToken;
 
     @Column(nullable = false)
-    private LocalDateTime expiresAt;
+    private Date expiresAt;
 
     public static RefreshToken createRefreshToken(
             String memberIdentifier,
             String refreshToken,
-            LocalDateTime expiresAt
+            Date expiresAt
     ) {
         RefreshToken token = new RefreshToken();
         token.setMemberIdentifier(memberIdentifier);

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/exception/JwtTokenException.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/exception/JwtTokenException.java
@@ -3,12 +3,12 @@ package com.jwt_auth_template.security.exception;
 import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.AuthenticationException;
 
-public class JwtException extends AuthenticationException {
-    public JwtException(@Nullable String msg, Throwable cause) {
+public class JwtTokenException extends AuthenticationException {
+    public JwtTokenException(@Nullable String msg, Throwable cause) {
         super(msg, cause);
     }
 
-    public JwtException(@Nullable String msg) {
+    public JwtTokenException(@Nullable String msg) {
         super(msg);
     }
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtProperties.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtProperties.java
@@ -1,0 +1,26 @@
+package com.jwt_auth_template.security.jwt;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Getter
+public class JwtProperties {
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-exptime}")
+    @Getter(AccessLevel.NONE)
+    private Duration accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-exptime}")
+    @Getter(AccessLevel.NONE)
+    private Duration refreshTokenExpiration;
+
+    private final long accessTokenTime=accessTokenExpiration.toMillis();
+
+    private final long refreshTokenTime=refreshTokenExpiration.toMillis();
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtProperties.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtProperties.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 
 @Getter
+@Component
 public class JwtProperties {
     @Value("${jwt.secret-key}")
     private String secretKey;
@@ -20,7 +21,11 @@ public class JwtProperties {
     @Getter(AccessLevel.NONE)
     private Duration refreshTokenExpiration;
 
-    private final long accessTokenTime=accessTokenExpiration.toMillis();
+    public long getAccessTokenTime() {
+        return accessTokenExpiration.toMillis();
+    }
 
-    private final long refreshTokenTime=refreshTokenExpiration.toMillis();
+    public long getRefreshTokenTime() {
+        return refreshTokenExpiration.toMillis();
+    }
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtTokenUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtTokenUtil.java
@@ -1,0 +1,109 @@
+package com.jwt_auth_template.security.jwt;
+
+import com.jwt_auth_template.jwt.RefreshToken;
+import com.jwt_auth_template.jwt.RefreshTokenRepository;
+import com.jwt_auth_template.security.exception.JwtTokenException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenUtil {
+    private final JwtProperties jwtProperties=new JwtProperties();
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private SecretKey key;
+
+    @PostConstruct
+    protected void init() {
+        key=new SecretKeySpec(
+                jwtProperties.getSecretKey()
+                        .getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS512.key().build().getAlgorithm()
+        );
+    }
+
+    public String generateJwtToken(JwtType jwtType,Date now,String memberIdentifier){
+        Date expDate = new Date(
+                now.getTime() +
+                        (jwtType == JwtType.REFRESH ? jwtProperties.getRefreshTokenTime() : jwtProperties.getAccessTokenTime())
+        );
+
+        String token = Jwts.builder()
+                .header()
+                .type(jwtType.name())
+                .and()
+                .subject(memberIdentifier)
+                .issuedAt(now)
+                .expiration(expDate)
+                .signWith(key)
+                .compact();
+
+        if(jwtType.equals(JwtType.REFRESH)){
+            RefreshToken refreshToken = RefreshToken.createRefreshToken(
+                    memberIdentifier,
+                    token,
+                    expDate
+            );
+            refreshTokenRepository.save(refreshToken);
+        }
+
+        return token;
+    }
+
+    public String extractJwtTokenFromRequest(HttpServletRequest request){
+        String token = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+
+        return null;
+    }
+
+    public String getMemberIdentifier(String jwtToken){
+
+        return getClaimsFromJwtToken(jwtToken)
+                .getSubject();
+    }
+
+    private Claims getClaimsFromJwtToken(String jwtToken){
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(jwtToken)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new JwtTokenException("Token has expired");
+        } catch (UnsupportedJwtException e) {
+            throw new JwtTokenException("Unsupported token");
+        } catch (SignatureException e){
+            throw new JwtTokenException("Token signature exception");
+        }catch (MalformedJwtException e) {
+            throw new JwtTokenException("Token is invalid");
+        } catch (IllegalArgumentException e) {
+            throw new JwtTokenException("Invalid JWT token");
+        }
+    }
+
+    public JwtType getJwtType(String jwtToken){
+        return JwtType.valueOf(Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(jwtToken)
+                .getHeader().getType()
+        );
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtTokenUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtTokenUtil.java
@@ -14,13 +14,12 @@ import org.springframework.util.StringUtils;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
 public class JwtTokenUtil {
-    private final JwtProperties jwtProperties=new JwtProperties();
+    private final JwtProperties jwtProperties;
     private final RefreshTokenRepository refreshTokenRepository;
 
     private SecretKey key;
@@ -63,10 +62,15 @@ public class JwtTokenUtil {
     }
 
     public String extractJwtTokenFromRequest(HttpServletRequest request){
-        String token = request.getHeader("Authorization");
+        String headerValue = request.getHeader("Authorization");
 
-        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
-            return token.substring(7);
+        if (StringUtils.hasText(headerValue) && headerValue.startsWith("Bearer ")) {
+            String token = headerValue.substring(7);
+
+            if(token.isEmpty())
+                return null;
+
+            return token;
         }
 
         return null;

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtType.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/jwt/JwtType.java
@@ -1,0 +1,5 @@
+package com.jwt_auth_template.security.jwt;
+
+public enum JwtType {
+    REFRESH,ACCESS
+}

--- a/jwt_auth_template/src/main/resources/application.properties
+++ b/jwt_auth_template/src/main/resources/application.properties
@@ -13,6 +13,6 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 
 ##
 
-jwt.secret-key=df
+jwt.secret-key=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD
 jwt.access-token-exptime=1d
 jwt.refresh-token-exptime=30d

--- a/jwt_auth_template/src/main/resources/application.properties
+++ b/jwt_auth_template/src/main/resources/application.properties
@@ -10,3 +10,9 @@ spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
+
+##
+
+jwt.secret-key=df
+jwt.access-token-exptime=1d
+jwt.refresh-token-exptime=30d

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/jwt/RefreshTokenRepositoryTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/jwt/RefreshTokenRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,7 +25,7 @@ class RefreshTokenRepositoryTest {
         RefreshToken refreshToken = RefreshToken.createRefreshToken(
                 "323",
                 "afsdasdf",
-                LocalDateTime.now()
+                new Date()
         );
         refreshTokenRepository.save(refreshToken);
 

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/security/jwt/JwtTokenUtilTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/security/jwt/JwtTokenUtilTest.java
@@ -1,0 +1,158 @@
+package com.jwt_auth_template.security.jwt;
+
+import com.jwt_auth_template.jwt.RefreshToken;
+import com.jwt_auth_template.jwt.RefreshTokenRepository;
+import com.jwt_auth_template.security.exception.JwtTokenException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        // HS512 테스트용(충분히 긴 secret)
+        "jwt.secret-key=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD",
+        // access 만료를 짧게 해서 만료 케이스 빠르게
+        "jwt.access-token-exptime=1s",
+        "jwt.refresh-token-exptime=30s"
+})
+class JwtTokenUtilTest {
+
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+
+    @MockitoBean
+    RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    void accessToken_발급_검증_멤버식별자_및_타입확인() {
+        // given
+        Date now = new Date();
+        String memberIdentifier = "member-123";
+
+        // when
+        String token = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, now, memberIdentifier);
+
+        // then
+        Assertions.assertThat(token).isNotBlank();
+        Assertions.assertThat(jwtTokenUtil.getMemberIdentifier(token)).isEqualTo(memberIdentifier);
+        Assertions.assertThat(jwtTokenUtil.getJwtType(token)).isEqualTo(JwtType.ACCESS);
+
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    void refreshToken_발급시_DB에_저장된다() {
+        // given
+        Date now = new Date();
+        String memberIdentifier = "member-999";
+
+        // when
+        String token = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, now, memberIdentifier);
+
+        // then
+        Assertions.assertThat(token).isNotBlank();
+        verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+
+        ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+        verify(refreshTokenRepository).save(captor.capture());
+
+        RefreshToken saved = captor.getValue();
+        Assertions.assertThat(saved.getMemberIdentifier()).isEqualTo(memberIdentifier);
+        Assertions.assertThat(saved.getRefreshToken()).isEqualTo(token);
+        Assertions.assertThat(saved.getExpiresAt()).isNotNull();
+    }
+
+    @Test
+    void 만료된_토큰이면_Expired_예외가_난다() {
+        // access-token-exptime=1s
+        // now를 2초 과거로 잡으면 exp가 과거가 됨
+        Date pastNow = new Date(System.currentTimeMillis() - 2000);
+
+        String token = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, pastNow, "member-expired");
+
+        // when / then
+        Assertions.assertThatThrownBy(() -> jwtTokenUtil.getMemberIdentifier(token))
+                .isInstanceOf(JwtTokenException.class)
+                .hasMessage("Token has expired");
+    }
+
+    @Test
+    void 토큰을_변조하면_서명검증_예외가_난다() {
+        String token = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, new Date(), "member-1");
+        String tampered = token.substring(0, token.length() - 1) + "x";
+
+        Assertions.assertThatThrownBy(() -> jwtTokenUtil.getMemberIdentifier(tampered))
+                .isInstanceOf(JwtTokenException.class)
+                .hasMessage("Token signature exception");
+    }
+
+    @Test
+    void 형식이_깨진_토큰이면_malformed_예외가_난다() {
+        // '.' 구분이 없어서 JJWT 파서가 보통 Malformed로 처리
+        String malformed = "this-is-not-a-jwt";
+
+        Assertions.assertThatThrownBy(() -> jwtTokenUtil.getMemberIdentifier(malformed))
+                .isInstanceOf(JwtTokenException.class)
+                // 네 코드에선 MalformedJwtException -> "Token is invalid"
+                .hasMessage("Token is invalid");
+    }
+
+    @Test
+    void null_토큰이면_invalid_예외가_난다() {
+        Assertions.assertThatThrownBy(() -> jwtTokenUtil.getMemberIdentifier(null))
+                .isInstanceOf(JwtTokenException.class)
+                .hasMessage("Invalid JWT token");
+    }
+
+    @Test
+    void getJwtType도_정상적으로_타입을_읽는다() {
+        String access = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, new Date(), "m1");
+        String refresh = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, new Date(), "m1");
+
+        Assertions.assertThat(jwtTokenUtil.getJwtType(access)).isEqualTo(JwtType.ACCESS);
+        Assertions.assertThat(jwtTokenUtil.getJwtType(refresh)).isEqualTo(JwtType.REFRESH);
+    }
+
+    @Test
+    void Authorization_Bearer_헤더에서_토큰을_추출한다() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader("Authorization")).thenReturn("Bearer abc.def.ghi");
+
+        String extracted = jwtTokenUtil.extractJwtTokenFromRequest(req);
+
+        Assertions.assertThat(extracted).isEqualTo("abc.def.ghi");
+    }
+
+    @Test
+    void Authorization_헤더가_없거나_Bearer가_아니면_null() {
+        HttpServletRequest req1 = mock(HttpServletRequest.class);
+        when(req1.getHeader("Authorization")).thenReturn(null);
+        Assertions.assertThat(jwtTokenUtil.extractJwtTokenFromRequest(req1)).isNull();
+
+        HttpServletRequest req2 = mock(HttpServletRequest.class);
+        when(req2.getHeader("Authorization")).thenReturn("");
+        Assertions.assertThat(jwtTokenUtil.extractJwtTokenFromRequest(req2)).isNull();
+
+        HttpServletRequest req3 = mock(HttpServletRequest.class);
+        when(req3.getHeader("Authorization")).thenReturn("Basic abc");
+        Assertions.assertThat(jwtTokenUtil.extractJwtTokenFromRequest(req3)).isNull();
+
+        HttpServletRequest req4 = mock(HttpServletRequest.class);
+        when(req4.getHeader("Authorization")).thenReturn("Bearer ");
+
+        Assertions.assertThat(jwtTokenUtil.extractJwtTokenFromRequest(req4)).isNull();
+    }
+}


### PR DESCRIPTION
#3 
목표

시큐리티/필터에서 재사용할 JWT 유틸(Provider)을 독립적으로 완성한다.

TODO

JwtProvider 구현: access/refresh 생성
-> JwtTokenUtil이름으로 구현
검증/파싱: 만료/서명/형식 오류 분류
->구현. 다양한 JWT 예외 JwtTokenUtil에서 throw
클레임 규칙 확정: sub, roles, tokenType, iat, exp
->확정. type은 access와 refresh 
설정값 외부화: secret, issuer, 만료시간 등 (application.yml)
->키와 만료시간만
완료 조건 (DoD)

단위 테스트 또는 간단 테스트 코드로 발급/검증/만료 케이스 확인
->모두 테스트로 검증.