### PR TITLE
Feat/#4

### DIFF
--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -44,6 +45,11 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .rememberMe(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        a->a.sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS
+                        )
+                )
 
 
                 .authorizeHttpRequests((configurer) -> configurer

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
@@ -1,0 +1,82 @@
+package com.jwt_auth_template.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return new ProviderManager(Arrays.asList(
+                //아직 provider 만든거 없음
+        ));
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors((registry) -> registry.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .rememberMe(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+
+
+                .authorizeHttpRequests((configurer) -> configurer
+                        .requestMatchers(HttpMethod.POST,
+                                "/auth/signup",
+                                "/auth/login",
+                                "/auth/reissue").anonymous()
+                        .requestMatchers(HttpMethod.GET,
+                                "/auth/me").authenticated()
+                        .requestMatchers(HttpMethod.GET,
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/favicon.ico").permitAll()
+                        .anyRequest().permitAll()
+                )
+
+                .build();
+    }
+
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
@@ -27,12 +27,13 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    @Bean
+    /*@Bean
     public AuthenticationManager authenticationManager() {
         return new ProviderManager(Arrays.asList(
                 //아직 provider 만든거 없음
         ));
-    }
+    }*/
+
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/test/TestController.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/test/TestController.java
@@ -1,0 +1,19 @@
+package com.jwt_auth_template.test;
+
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+    @GetMapping("/")
+    public String index() {
+        return "Hello World";
+    }
+
+    @GetMapping("/auth/me")
+    public String me() {
+        return "Hello Me";
+    }
+}


### PR DESCRIPTION
#4
목표

“REST 서버 + JWT”에 맞는 최소 보안 설정을 먼저 고정한다.

TODO

세션 사용 안함: STATELESS
-> 완료
csrf 비활성화(순수 REST 기준)
-> 완료
formLogin/httpBasic 비활성화
-> 완료
authorizeHttpRequests로 permitAll 적용
-> 완료
CORS 설정(프론트 도메인/허용 헤더 Authorization/노출 헤더 등)
-> 임시 완료
AuthenticationManager, PasswordEncoder 등 필요한 빈 정리(향후 확장 대비)
-> 완료. AuthenticationManger는 provider구현후 등록
완료 조건 (DoD)

서버 기동 시 시큐리티 설정이 반영되고, permitAll 엔드포인트 접근 가능
-> 완료