### PR TITLE
Feat/#5

### DIFF
--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/RestClientConfig.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/RestClientConfig.java
@@ -1,0 +1,19 @@
+package com.jwt_auth_template;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient kakaoRestClient(RestClient.Builder builder) {
+        return builder
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthController.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthController.java
@@ -1,0 +1,50 @@
+package com.jwt_auth_template.auth;
+
+import com.jwt_auth_template.auth.dto.JoinWithKakaoRequestDto;
+import com.jwt_auth_template.auth.dto.LoginSuccessResponseDto;
+import com.jwt_auth_template.auth.dto.LoginWithKakaoRequestDto;
+import com.jwt_auth_template.member.AuthType;
+import com.jwt_auth_template.member.Member;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+
+    @PostMapping("/joinWithKakao")
+    public LoginSuccessResponseDto joinWithKakao(
+            @RequestBody JoinWithKakaoRequestDto joinWithKakaoRequestDto,
+            HttpServletResponse response
+    ) {
+        Member member = authService.joinWithKakao(joinWithKakaoRequestDto);
+
+        String accessToken =
+                authService.enrollAuthTokens(member.getId().toString(), response);
+
+        return new LoginSuccessResponseDto(accessToken);
+    }
+
+    @PostMapping("/loginWithKakao")
+    public LoginSuccessResponseDto login(
+            @RequestBody LoginWithKakaoRequestDto loginWithKakaoRequestDto,
+            HttpServletResponse response
+    ) {
+        Member member = authService.findMemberWithOauthToken(
+                loginWithKakaoRequestDto.getOauthToken(),
+                AuthType.KAKAO
+        );
+
+        String accessToken =
+                authService.enrollAuthTokens(member.getId().toString(), response);
+
+        return new LoginSuccessResponseDto(accessToken);
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
@@ -1,0 +1,75 @@
+package com.jwt_auth_template.auth;
+
+import com.jwt_auth_template.auth.dto.JoinWithKakaoRequestDto;
+import com.jwt_auth_template.auth.dto.OAuthMemberInfo;
+import com.jwt_auth_template.auth.exception.OAuthException;
+import com.jwt_auth_template.jwt.JwtTokenUtil;
+import com.jwt_auth_template.jwt.JwtType;
+import com.jwt_auth_template.jwt.RefreshTokenEntity;
+import com.jwt_auth_template.member.AuthType;
+import com.jwt_auth_template.member.Member;
+import com.jwt_auth_template.member.MemberRole;
+import com.jwt_auth_template.member.MemberService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberService memberService;
+    private final KakaoOAuthUtil kakaoOAuthUtil;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    public Member joinWithKakao(JoinWithKakaoRequestDto joinWithKakaoRequestDto) {
+
+        String oauthToken = joinWithKakaoRequestDto.getOauthToken();
+        OAuthMemberInfo oauthMemberInfo = kakaoOAuthUtil.getMemberInfoFromOAuthToken(oauthToken);
+
+        Member member = Member.createMember(
+                true,
+                oauthMemberInfo.getName(),
+                MemberRole.USER,
+                oauthMemberInfo.getAuthType(),
+                oauthMemberInfo.getOauthId(),
+                null
+        );
+        return memberService.save(member);
+    }
+
+    public String enrollAuthTokens(String memberIdentifier, HttpServletResponse response) {
+        Date issuedAt = new Date();
+        String accessToken = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, issuedAt, memberIdentifier);
+        String refreshToken = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, issuedAt, memberIdentifier);
+
+        RefreshTokenEntity refreshTokenEntity =
+                jwtTokenUtil.generateRefreshTokenEntity(
+                        memberIdentifier,
+                        refreshToken,
+                        issuedAt
+                );
+        jwtTokenUtil.saveRefreshTokenEntity(refreshTokenEntity);
+        jwtTokenUtil.setCookieRefreshToken(refreshTokenEntity, response);
+
+        return accessToken;
+    }
+
+    public Member findMemberWithOauthToken(String oauthToken, AuthType authType) {
+
+        OAuthMemberInfo oauthMemberInfo=switch (authType){
+            case AuthType.KAKAO -> kakaoOAuthUtil.getMemberInfoFromOAuthToken(oauthToken);
+            case AuthType.NAVER -> null;
+            default -> null;
+        };
+
+        if(oauthMemberInfo==null) {
+            throw new OAuthException("cannot extract member info from oauth token");
+        }
+
+        return memberService.getActiveOAuthMember(oauthMemberInfo);
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/KakaoOAuthUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/KakaoOAuthUtil.java
@@ -1,4 +1,53 @@
 package com.jwt_auth_template.auth;
 
+import com.jwt_auth_template.auth.dto.OAuthMemberInfo;
+import com.jwt_auth_template.auth.exception.OAuthException;
+import com.jwt_auth_template.member.AuthType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@Component
+@RequiredArgsConstructor
 public class KakaoOAuthUtil {
+    private static final String PROPERTY_KEYS = "[\"kakao_account.profile\"]";
+
+    private final RestClient kakaoRestClient;
+    private final ObjectMapper objectMapper;
+
+    public OAuthMemberInfo getMemberInfoFromOAuthToken(String oAuthToken) {
+        String body = kakaoRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v2/user/me")
+                        .queryParam("property_keys", PROPERTY_KEYS)
+                        .build())
+                .headers(headers -> headers.setBearerAuth(oAuthToken))
+                .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (request, response) ->
+                        {
+                            throw new OAuthException("Kakao API error: " + response.getStatusCode());
+                        }
+                )
+                .body(String.class);
+
+        try {
+            JsonNode json = objectMapper.readTree(body);
+
+            String name = json.path("kakao_account")
+                    .path("profile")
+                    .path("nickname")
+                    .asString();
+
+            String kakaoId = json.path("id").asString();
+
+            return new OAuthMemberInfo(name, kakaoId, AuthType.KAKAO);
+        } catch (Exception e) {
+            throw new OAuthException("Failed to parse Kakao response", e);
+        }
+    }
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/KakaoOAuthUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/KakaoOAuthUtil.java
@@ -1,0 +1,4 @@
+package com.jwt_auth_template.auth;
+
+public class KakaoOAuthUtil {
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/JoinWithKakaoRequestDto.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/JoinWithKakaoRequestDto.java
@@ -6,5 +6,5 @@ import lombok.Setter;
 @Getter
 @Setter
 public class JoinWithKakaoRequestDto {
-    private String oAuthAccessToken;
+    private String oauthToken;
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/LoginSuccessResponseDto.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/LoginSuccessResponseDto.java
@@ -3,6 +3,6 @@ package com.jwt_auth_template.auth.dto;
 import lombok.Setter;
 
 @Setter
-public class LoginSuccessResponse {
+public class LoginSuccessResponseDto {
     private String accessToken;
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/LoginSuccessResponseDto.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/LoginSuccessResponseDto.java
@@ -1,8 +1,12 @@
 package com.jwt_auth_template.auth.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.Setter;
 
 @Setter
+@Getter
+@AllArgsConstructor
 public class LoginSuccessResponseDto {
     private String accessToken;
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/LoginWithKakaoRequestDto.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/LoginWithKakaoRequestDto.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
 public class LoginWithKakaoRequestDto {
     private String oAuthToken;
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/LoginWithKakaoRequestDto.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/LoginWithKakaoRequestDto.java
@@ -1,11 +1,10 @@
 package com.jwt_auth_template.auth.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class LoginWithKakaoRequestDto {
-    private String oAuthToken;
+    private String oauthToken;
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/OAuthMemberInfo.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/OAuthMemberInfo.java
@@ -1,0 +1,15 @@
+package com.jwt_auth_template.auth.dto;
+
+import com.jwt_auth_template.member.AuthType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class OAuthMemberInfo {
+    private String name;
+
+    private String oauthId;
+
+    private AuthType authType;
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtProperties.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtProperties.java
@@ -1,4 +1,4 @@
-package com.jwt_auth_template.security.jwt;
+package com.jwt_auth_template.jwt;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
@@ -1,7 +1,5 @@
-package com.jwt_auth_template.security.jwt;
+package com.jwt_auth_template.jwt;
 
-import com.jwt_auth_template.jwt.RefreshToken;
-import com.jwt_auth_template.jwt.RefreshTokenRepository;
 import com.jwt_auth_template.security.exception.JwtTokenException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SignatureException;

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtType.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtType.java
@@ -1,4 +1,4 @@
-package com.jwt_auth_template.security.jwt;
+package com.jwt_auth_template.jwt;
 
 public enum JwtType {
     REFRESH,ACCESS

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshToken.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshToken.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
@@ -10,11 +10,11 @@ import java.util.Date;
 @Entity
 @Getter
 @Setter
-public class RefreshToken {
+public class RefreshTokenEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="refresh_token_id")
+    @Column(name="refresh_token_entity_id")
     @Setter(AccessLevel.NONE)
     private Long id;
 
@@ -27,12 +27,12 @@ public class RefreshToken {
     @Column(nullable = false)
     private Date expiresAt;
 
-    public static RefreshToken createRefreshToken(
+    public static RefreshTokenEntity createRefreshToken(
             String memberIdentifier,
             String refreshToken,
             Date expiresAt
     ) {
-        RefreshToken token = new RefreshToken();
+        RefreshTokenEntity token = new RefreshTokenEntity();
         token.setMemberIdentifier(memberIdentifier);
         token.setRefreshToken(refreshToken);
         token.setExpiresAt(expiresAt);

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
@@ -3,5 +3,7 @@ package com.jwt_auth_template.jwt;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository
-        extends JpaRepository<RefreshToken, Long> {
+        extends JpaRepository<RefreshTokenEntity, Long> {
+
+    int deleteByMemberIdentifier(String memberIdentifier);
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/AuthType.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/AuthType.java
@@ -1,5 +1,5 @@
 package com.jwt_auth_template.member;
 
 public enum AuthType {
-    EMAIL,KAKAO
+    EMAIL,KAKAO,NAVER,GOOGLE
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/Member.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/Member.java
@@ -17,7 +17,7 @@ public class Member {
     private Long id;
 
     @Column(nullable = false)
-    private boolean isActive;
+    private boolean active;
 
     @Column(nullable = false)
     private String name;
@@ -42,6 +42,7 @@ public class Member {
             String name,
             MemberRole memberRole,
             AuthType authType,
+            String oauthId,
             String password
     ) {
         Member member = new Member();
@@ -49,6 +50,7 @@ public class Member {
         member.setName(name);
         member.setMemberRole(memberRole);
         member.setAuthType(authType);
+        member.setOauthId(oauthId);
         member.setPassword(password);
         return member;
     }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberException.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberException.java
@@ -1,0 +1,11 @@
+package com.jwt_auth_template.member;
+
+public class MemberException extends IllegalStateException{
+    public MemberException(String s) {
+        super(s);
+    }
+
+    public MemberException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberRepository.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberRepository.java
@@ -9,5 +9,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("update Member m set m.isActive = :active where m.id = :id")
     @Modifying
     int updateActiveById(boolean active, Long id);
+
+    Member findByEmailAndActive(String email, boolean active);
+
+    Member findByOauthIdAndActive(String oauthId, boolean active);
 }
 

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberRepository.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberRepository.java
@@ -5,13 +5,17 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    @Query("update Member m set m.isActive = :active where m.id = :id")
+    @Query("update Member m set m.active = :active where m.id = :id")
     @Modifying
     int updateActiveById(boolean active, Long id);
 
-    Member findByEmailAndActive(String email, boolean active);
+    Optional<Member> findByEmailAndActive(String email, boolean active);
 
-    Member findByOauthIdAndActive(String oauthId, boolean active);
+    Optional<Member> findByOauthIdAndActive(String oauthId, boolean active);
+
+    Optional<Member> findByOauthIdAndNameAndAuthType(String oauthId, String name, AuthType authType);
 }
 

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberService.java
@@ -1,0 +1,48 @@
+package com.jwt_auth_template.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.core.support.RepositoryMethodInvocationListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final RepositoryMethodInvocationListener repositoryMethodInvocationListener;
+
+    public Member save(final Member member) {
+        validateDuplicate(member);
+
+        return memberRepository.save(member);
+    }
+
+    private void validateDuplicate(final Member member) {
+        Member findMember = switch (member.getAuthType()) {
+            case EMAIL ->
+                    memberRepository.findByEmailAndActive(member.getEmail(),true);
+            case KAKAO ->
+                    memberRepository.findByOauthIdAndActive(member.getOauthId(),true);
+            default -> null;
+        };
+
+        if(findMember != null) {
+            throw new MemberException("member already exists");
+        }
+    }
+
+    public Member getActiveMember(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new MemberException("member not found with id: " + id));
+
+        if (!member.isActive()) {
+            throw new MemberException("member inactivated");
+        }
+        return member;
+    }
+
+    public void delete(final Member member) {
+        memberRepository.updateActiveById(false, member.getId());
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests((configurer) -> configurer
                         .requestMatchers(HttpMethod.POST,
-                                "/auth/signup",
+                                "/auth/join",
                                 "/auth/login",
                                 "/auth/reissue").anonymous()
                         .requestMatchers(HttpMethod.GET,

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/test/TestController.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/test/TestController.java
@@ -31,7 +31,7 @@ public class TestController {
             @RequestBody
             LoginWithKakaoRequestDto loginWithKakaoRequestDto
     ) {
-        System.out.println("loginWithKakaoRequestDto.getOAuthToken() = " + loginWithKakaoRequestDto.getOAuthToken());
-        return ResponseEntity.ok(kakaoOAuthUtil.getMemberInfoFromOAuthToken(loginWithKakaoRequestDto.getOAuthToken()));
+        System.out.println("loginWithKakaoRequestDto.getOauthToken() = " + loginWithKakaoRequestDto.getOauthToken());
+        return ResponseEntity.ok(kakaoOAuthUtil.getMemberInfoFromOAuthToken(loginWithKakaoRequestDto.getOauthToken()));
     }
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/test/TestController.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/test/TestController.java
@@ -1,7 +1,13 @@
 package com.jwt_auth_template.test;
 
 
+import com.jwt_auth_template.auth.KakaoOAuthUtil;
+import com.jwt_auth_template.auth.dto.LoginWithKakaoRequestDto;
+import com.jwt_auth_template.auth.dto.OAuthMemberInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -15,5 +21,17 @@ public class TestController {
     @GetMapping("/auth/me")
     public String me() {
         return "Hello Me";
+    }
+
+    @Autowired
+    private KakaoOAuthUtil kakaoOAuthUtil;
+
+    @GetMapping("/kakaoTest")
+    public ResponseEntity<OAuthMemberInfo> kakaoTest(
+            @RequestBody
+            LoginWithKakaoRequestDto loginWithKakaoRequestDto
+    ) {
+        System.out.println("loginWithKakaoRequestDto.getOAuthToken() = " + loginWithKakaoRequestDto.getOAuthToken());
+        return ResponseEntity.ok(kakaoOAuthUtil.getMemberInfoFromOAuthToken(loginWithKakaoRequestDto.getOAuthToken()));
     }
 }

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/auth/KakaoOAuthUtilTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/auth/KakaoOAuthUtilTest.java
@@ -1,0 +1,112 @@
+package com.jwt_auth_template.auth;
+
+import com.jwt_auth_template.auth.dto.OAuthMemberInfo;
+import com.jwt_auth_template.auth.exception.OAuthException;
+import com.jwt_auth_template.member.AuthType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restclient.test.autoconfigure.RestClientTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.*;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+@RestClientTest(KakaoOAuthUtil.class)
+class KakaoOAuthUtilTest {
+
+    private static final String PROPERTY_KEYS = "[\"kakao_account.profile\"]";
+
+    @Autowired KakaoOAuthUtil kakaoOAuthUtil;
+    @Autowired MockRestServiceServer server;
+
+    @AfterEach
+    void tearDown() {
+        server.verify();
+    }
+
+    private String expectedUserMeUri() {
+        // ✅ RestClient가 만드는 실제 URI와 동일하게(인코딩 포함) 생성
+        return UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v2/user/me")
+                .queryParam("property_keys", PROPERTY_KEYS)
+                .build()
+                .encode()
+                .toUriString();
+    }
+
+    @Test
+    void 토큰으로_회원정보를_정상조회한다() {
+        String token = "test-oauth-token";
+        String kakaoResponseJson = """
+            {
+              "id": 123456789,
+              "kakao_account": { "profile": { "nickname": "kkh" } }
+            }
+            """;
+
+        server.expect(requestTo(expectedUserMeUri()))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andRespond(withSuccess(kakaoResponseJson, MediaType.APPLICATION_JSON));
+
+        OAuthMemberInfo actual = kakaoOAuthUtil.getMemberInfoFromOAuthToken(token);
+
+        OAuthMemberInfo expected = new OAuthMemberInfo("kkh", "123456789", AuthType.KAKAO);
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void 카카오_API가_에러응답이면_OAuthException을_던진다() {
+        String token = "bad-token";
+
+        server.expect(requestTo(expectedUserMeUri()))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"msg\":\"Unauthorized\"}"));
+
+        assertThatThrownBy(() -> kakaoOAuthUtil.getMemberInfoFromOAuthToken(token))
+                .isInstanceOf(OAuthException.class)
+                .hasMessageContaining("Kakao API error");
+    }
+
+    @Test
+    void 응답_JSON이_깨져있으면_OAuthException을_던진다() {
+        String token = "test-token";
+
+        server.expect(requestTo(expectedUserMeUri()))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andRespond(withSuccess("NOT_A_JSON", MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> kakaoOAuthUtil.getMemberInfoFromOAuthToken(token))
+                .isInstanceOf(OAuthException.class)
+                .hasMessageContaining("Failed to parse Kakao response");
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        RestClient kakaoRestClient(RestClient.Builder builder) {
+            return builder
+                    .baseUrl("https://kapi.kakao.com")
+                    .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                    .build();
+        }
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+}

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/jwt/RefreshTokenRepositoryTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/jwt/RefreshTokenRepositoryTest.java
@@ -6,12 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DateTimeException;
-import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/jwt/RefreshTokenRepositoryTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/jwt/RefreshTokenRepositoryTest.java
@@ -18,20 +18,20 @@ class RefreshTokenRepositoryTest {
 
     @Test
     void setAndGetRefreshToken() {
-        RefreshToken refreshToken = RefreshToken.createRefreshToken(
+        RefreshTokenEntity refreshTokenEntity = RefreshTokenEntity.createRefreshToken(
                 "323",
                 "afsdasdf",
                 new Date()
         );
-        refreshTokenRepository.save(refreshToken);
+        refreshTokenRepository.save(refreshTokenEntity);
 
-        Optional<RefreshToken> findRefreshToken =
+        Optional<RefreshTokenEntity> findRefreshToken =
                 refreshTokenRepository
-                        .findById(refreshToken.getId());
+                        .findById(refreshTokenEntity.getId());
 
         Assertions.assertThat(findRefreshToken).isPresent();
         Assertions.assertThat(findRefreshToken.get())
-                .isEqualTo(refreshToken);
+                .isEqualTo(refreshTokenEntity);
     }
 
 }

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/security/jwt/JwtTokenUtilTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/security/jwt/JwtTokenUtilTest.java
@@ -2,7 +2,7 @@ package com.jwt_auth_template.security.jwt;
 
 import com.jwt_auth_template.jwt.JwtTokenUtil;
 import com.jwt_auth_template.jwt.JwtType;
-import com.jwt_auth_template.jwt.RefreshToken;
+import com.jwt_auth_template.jwt.RefreshTokenEntity;
 import com.jwt_auth_template.jwt.RefreshTokenRepository;
 import com.jwt_auth_template.security.exception.JwtTokenException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -63,12 +63,12 @@ class JwtTokenUtilTest {
 
         // then
         Assertions.assertThat(token).isNotBlank();
-        verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+        verify(refreshTokenRepository, times(1)).save(any(RefreshTokenEntity.class));
 
-        ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+        ArgumentCaptor<RefreshTokenEntity> captor = ArgumentCaptor.forClass(RefreshTokenEntity.class);
         verify(refreshTokenRepository).save(captor.capture());
 
-        RefreshToken saved = captor.getValue();
+        RefreshTokenEntity saved = captor.getValue();
         Assertions.assertThat(saved.getMemberIdentifier()).isEqualTo(memberIdentifier);
         Assertions.assertThat(saved.getRefreshToken()).isEqualTo(token);
         Assertions.assertThat(saved.getExpiresAt()).isNotNull();

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/security/jwt/JwtTokenUtilTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/security/jwt/JwtTokenUtilTest.java
@@ -1,5 +1,7 @@
 package com.jwt_auth_template.security.jwt;
 
+import com.jwt_auth_template.jwt.JwtTokenUtil;
+import com.jwt_auth_template.jwt.JwtType;
 import com.jwt_auth_template.jwt.RefreshToken;
 import com.jwt_auth_template.jwt.RefreshTokenRepository;
 import com.jwt_auth_template.security.exception.JwtTokenException;
@@ -7,16 +9,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Date;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 


### PR DESCRIPTION
#5 

목표

프론트에서 받은 code 또는 외부 accessToken으로 사용자 정보를 확보하고, 내부 JWT를 발급한다. -> accessToken받습니다.

TODO

외부 인증 어댑터 인터페이스 설계 (OAuthClient 등) -> code를 사용하지 않으니 필요없습니다.
->예정대로 필요없음.
“코드→토큰교환” 또는 “외부 토큰→유저정보조회” 구현(프로젝트 요구에 맞게)
-> KakaoOAuthUtil로 구현.
사용자 프로비저닝(신규 생성/기존 업데이트)
->MemberService로 구현.
내부 accessToken 발급 + 응답 DTO로 반환
->AuthService로 구현.
refreshToken 생성 후 DB 저장
->JwtTokenUtil에 구현.
완료 조건 (DoD)

/auth/join 또는 /auth/login 호출 시 accessToken이 응답되고 refreshToken이 DB에 저장됨
->AuthController로 확인.