### PR TITLE
Feat/#8

### DIFF
--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthController.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthController.java
@@ -69,7 +69,7 @@ public class AuthController {
             @CookieValue(required = false) String refreshToken,
             HttpServletResponse response
     ) {
-        authService.clearRefreshTokenAndRefreshTokenEntity(refreshToken, response);
+        authService.clearRefreshTokenAndEntity(refreshToken, response);
 
         return ResponseEntity.ok(ApiResponse.ok("logout success"));
     }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthController.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthController.java
@@ -1,20 +1,15 @@
 package com.jwt_auth_template.auth;
 
-import com.jwt_auth_template.auth.dto.JoinWithKakaoRequestDto;
-import com.jwt_auth_template.auth.dto.LoginSuccessResponseDto;
-import com.jwt_auth_template.auth.dto.LoginWithKakaoRequestDto;
-import com.jwt_auth_template.auth.dto.MeResponseDto;
+import com.jwt_auth_template.auth.dto.*;
+import com.jwt_auth_template.exception.ApiResponse;
 import com.jwt_auth_template.member.AuthType;
 import com.jwt_auth_template.member.Member;
-import com.jwt_auth_template.member.MemberRole;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
+import java.util.Date;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,20 +19,23 @@ public class AuthController {
 
 
     @PostMapping("/joinWithKakao")
-    public LoginSuccessResponseDto joinWithKakao(
+    public ResponseEntity<ApiResponse<LoginSuccessResponseDto>> joinWithKakao(
             @RequestBody JoinWithKakaoRequestDto joinWithKakaoRequestDto,
             HttpServletResponse response
     ) {
         Member member = authService.joinWithKakao(joinWithKakaoRequestDto);
 
         String accessToken =
-                authService.enrollAuthTokens(member.getId().toString(), response);
+                authService.enrollNewAuthTokens(member.getId().toString(), response,new Date());
 
-        return new LoginSuccessResponseDto(accessToken);
+        return ResponseEntity.ok(
+                ApiResponse.ok(new LoginSuccessResponseDto(accessToken))
+        );
     }
 
+
     @PostMapping("/loginWithKakao")
-    public LoginSuccessResponseDto login(
+    public ResponseEntity<ApiResponse<LoginSuccessResponseDto>> login(
             @RequestBody LoginWithKakaoRequestDto loginWithKakaoRequestDto,
             HttpServletResponse response
     ) {
@@ -47,10 +45,32 @@ public class AuthController {
         );
 
         String accessToken =
-                authService.enrollAuthTokens(member.getId().toString(), response);
+                authService.enrollNewAuthTokens(member.getId().toString(), response,new Date());
 
-        return new LoginSuccessResponseDto(accessToken);
+        return ResponseEntity.ok(
+                ApiResponse.ok(new LoginSuccessResponseDto(accessToken))
+        );
     }
 
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<ReissueSuccessResponseDto>> reissue(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ){
+        String accessToken = authService.reissueAccessToken(refreshToken, response);
 
+        return ResponseEntity.ok(
+                ApiResponse.ok(new ReissueSuccessResponseDto(accessToken))
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        authService.clearRefreshTokenAndRefreshTokenEntity(refreshToken, response);
+
+        return ResponseEntity.ok(ApiResponse.ok("logout success"));
+    }
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
@@ -3,10 +3,13 @@ package com.jwt_auth_template.auth;
 import com.jwt_auth_template.auth.dto.JoinWithKakaoRequestDto;
 import com.jwt_auth_template.auth.dto.OAuthMemberInfo;
 import com.jwt_auth_template.exception.ErrorCode;
+import com.jwt_auth_template.exception.JwtValidAuthenticationException;
 import com.jwt_auth_template.exception.OAuthException;
+import com.jwt_auth_template.exception.ReissueException;
 import com.jwt_auth_template.jwt.JwtTokenUtil;
 import com.jwt_auth_template.jwt.JwtType;
 import com.jwt_auth_template.jwt.RefreshTokenEntity;
+import com.jwt_auth_template.jwt.RefreshTokenRepository;
 import com.jwt_auth_template.member.AuthType;
 import com.jwt_auth_template.member.Member;
 import com.jwt_auth_template.member.MemberRole;
@@ -25,6 +28,7 @@ public class AuthService {
     private final MemberService memberService;
     private final KakaoOAuthUtil kakaoOAuthUtil;
     private final JwtTokenUtil jwtTokenUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public Member joinWithKakao(JoinWithKakaoRequestDto joinWithKakaoRequestDto) {
 
@@ -42,19 +46,15 @@ public class AuthService {
         return memberService.save(member);
     }
 
-    public String enrollAuthTokens(String memberIdentifier, HttpServletResponse response) {
-        Date issuedAt = new Date();
+    public String enrollNewAuthTokens(String memberIdentifier, HttpServletResponse response, Date issuedAt) {
         String accessToken = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, issuedAt, memberIdentifier);
         String refreshToken = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, issuedAt, memberIdentifier);
 
         RefreshTokenEntity refreshTokenEntity =
-                jwtTokenUtil.generateRefreshTokenEntity(
-                        memberIdentifier,
-                        refreshToken,
-                        issuedAt
-                );
-        jwtTokenUtil.saveRefreshTokenEntity(refreshTokenEntity);
-        jwtTokenUtil.setCookieRefreshToken(refreshTokenEntity, response);
+                jwtTokenUtil.generateRefreshTokenEntity(memberIdentifier,refreshToken,issuedAt);
+
+        jwtTokenUtil.upsertRefreshTokenEntity(refreshTokenEntity);
+        jwtTokenUtil.generateCookieRefreshToken(refreshTokenEntity, response);
 
         return accessToken;
     }
@@ -72,5 +72,33 @@ public class AuthService {
         }
 
         return memberService.getActiveOAuthMember(oauthMemberInfo);
+    }
+
+    public String reissueAccessToken(String refreshToken,HttpServletResponse response){
+        try{
+            String memberIdentifier = jwtTokenUtil.getMemberIdentifier(refreshToken);
+
+            RefreshTokenEntity refreshTokenEntity = refreshTokenRepository.findByRefreshToken(refreshToken);
+
+            return enrollNewAuthTokens(memberIdentifier,response,refreshTokenEntity.getIssuedAt());
+        }
+        catch(JwtValidAuthenticationException e){
+            switch(e.getErrorCode()){
+                case ErrorCode.JWT_ERROR -> {//높은 확률로 replay attack
+                    
+
+                    throw new ReissueException(ErrorCode.JWT_REISSUE_ERROR);
+                }
+                case ErrorCode.JWT_EXPIRED -> throw new ReissueException(ErrorCode.JWT_REISSUE_EXPIRED);
+                default -> throw new ReissueException(ErrorCode.REISSUE_ERROR);
+            }
+        }
+    }
+
+    public void clearRefreshTokenAndRefreshTokenEntity(String refreshToken, HttpServletResponse response) {
+        if(refreshToken!=null) {
+            jwtTokenUtil.eraseCookieRefreshToken(response);
+            jwtTokenUtil.deleteRefreshTokenEntity(refreshToken);
+        }
     }
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
@@ -79,7 +79,7 @@ public class AuthService {
             //검증과 식별자 추출
             String memberIdentifier = jwtTokenUtil.getMemberIdentifier(refreshToken);
 
-            return enrollNewAuthTokens(memberIdentifier, response, refreshTokenEntity.getIssuedAt());
+            return  enrollNewAuthTokens(memberIdentifier, response, refreshTokenEntity.getIssuedAt());
         } catch (JwtValidAuthenticationException e) {
 
             switch (e.getErrorCode()) {

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/ReissueSuccessResponseDto.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/dto/ReissueSuccessResponseDto.java
@@ -1,0 +1,13 @@
+package com.jwt_auth_template.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class ReissueSuccessResponseDto {
+
+    private String accessToken;
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/AuthGlobalExceptionHandler.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/AuthGlobalExceptionHandler.java
@@ -25,6 +25,14 @@ public class AuthGlobalExceptionHandler {
         return buildErrorResponse(exception.getErrorCode());
     }
 
+    //AuthController 내에서 발생하는 JwtValidAuthentication 에러는 토큰 리이슈 관련 에러입니다.
+    @ExceptionHandler(ReissueException.class)
+    public ResponseEntity<ApiResponse<Void>> handleReissueException(
+            final ReissueException exception
+    ) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
 
     private ResponseEntity<ApiResponse<Void>> buildErrorResponse(ErrorCode errorCode) {
         return ResponseEntity

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/ErrorCode.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/ErrorCode.java
@@ -13,9 +13,12 @@ public enum ErrorCode {
     CONFLICT("GEN-004", HttpStatus.CONFLICT, "Conflict"),
     INTERNAL_SERVER_ERROR("GEN-005", HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
 
-    //AUTHENTICATE & SECURITY
+    //인증관련
     JWT_ERROR("JWT_001", HttpStatus.UNAUTHORIZED, "JWT General Error"),
     JWT_EXPIRED("JWT_002", HttpStatus.UNAUTHORIZED, "JWT Expired"),
+    JWT_REISSUE_ERROR("JWT_003", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token General Error"),
+    JWT_REISSUE_EXPIRED("JWT_004", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Expired"),
+    REISSUE_ERROR("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
 
     UNAUTHENTICATED("SEC-001", HttpStatus.UNAUTHORIZED, "Unauthenticated"),
     UNAUTHORIZED("SEC-002", HttpStatus.FORBIDDEN, "Unauthorized"),
@@ -23,7 +26,6 @@ public enum ErrorCode {
     MEMBER_NOTFOUND("SEC-004", HttpStatus.INTERNAL_SERVER_ERROR, "Member Not Found"),
 
     OAUTH_RESOURCE_ERROR("OAUTH-001", HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Unavailable");
-
 
     private final String code;
     private final HttpStatus status;

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/ReissueException.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/ReissueException.java
@@ -1,0 +1,7 @@
+package com.jwt_auth_template.exception;
+
+public class ReissueException extends ApiException{
+    public ReissueException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
@@ -10,12 +10,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -48,6 +51,7 @@ public class JwtTokenUtil {
                 .issuedAt(now)
                 .expiration(expDate)
                 .signWith(key)
+                .id(UUID.randomUUID().toString())
                 .compact();
     }
 
@@ -74,9 +78,11 @@ public class JwtTokenUtil {
         refreshTokenRepository.save(refreshTokenEntity);
     }
 
-    public void deleteAllRefreshTokenEntity(String memberIdentifier) {
-        refreshTokenRepository.deleteByMemberIdentifier(memberIdentifier);
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int deleteAllRefreshTokenEntity(String memberIdentifier) {
+        int count = refreshTokenRepository.deleteByMemberIdentifier(memberIdentifier);
         refreshTokenRepository.flush();
+        return count;
     }
 
     public RefreshTokenEntity getRefreshTokenEntity(String refreshToken) {

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
@@ -67,17 +67,21 @@ public class JwtTokenUtil {
         );
     }
 
+
     //@Transactional
     public void upsertRefreshTokenEntity(RefreshTokenEntity refreshTokenEntity) {
-        refreshTokenRepository.deleteByMemberIdentifier(refreshTokenEntity.getMemberIdentifier());
-        refreshTokenRepository.flush();
+        deleteAllRefreshTokenEntity(refreshTokenEntity.getMemberIdentifier());
         refreshTokenRepository.save(refreshTokenEntity);
     }
 
-    public void deleteRefreshTokenEntity(String refreshToken) {
-        refreshTokenRepository.deleteByRefreshToken(refreshToken);
+    public void deleteAllRefreshTokenEntity(String memberIdentifier) {
+        refreshTokenRepository.deleteByMemberIdentifier(memberIdentifier);
+        refreshTokenRepository.flush();
     }
 
+    public RefreshTokenEntity getRefreshTokenEntity(String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken);
+    }
 
     public void generateCookieRefreshToken(RefreshTokenEntity refreshTokenEntity, HttpServletResponse response) {
         Cookie cookie = new Cookie("refreshToken", refreshTokenEntity.getRefreshToken());
@@ -95,6 +99,8 @@ public class JwtTokenUtil {
         cookie.setMaxAge(0);
         response.addCookie(cookie);
     }
+
+
 
     public String extractJwtTokenFromRequest(HttpServletRequest request) {
         String headerValue = request.getHeader("Authorization");

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
@@ -18,7 +18,7 @@ public class RefreshTokenEntity {
     @Setter(AccessLevel.NONE)
     private Long id;
 
-    @Column(nullable = false,unique = true)
+    @Column(nullable = false,unique = true,updatable = false)
     private String memberIdentifier;
 
     @Column(nullable = false)

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
@@ -25,16 +25,21 @@ public class RefreshTokenEntity {
     private String refreshToken;
 
     @Column(nullable = false)
+    private Date issuedAt;
+
+    @Column(nullable = false)
     private Date expiresAt;
 
     public static RefreshTokenEntity createRefreshToken(
             String memberIdentifier,
             String refreshToken,
+            Date issuedAt,
             Date expiresAt
     ) {
         RefreshTokenEntity token = new RefreshTokenEntity();
         token.setMemberIdentifier(memberIdentifier);
         token.setRefreshToken(refreshToken);
+        token.setIssuedAt(issuedAt);
         token.setExpiresAt(expiresAt);
         return token;
     }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
@@ -9,7 +9,5 @@ public interface RefreshTokenRepository
 
     int deleteByMemberIdentifier(String memberIdentifier);
 
-    int deleteByRefreshToken(String refreshToken);
-
     RefreshTokenEntity findByRefreshToken(String refreshToken);
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
@@ -1,6 +1,8 @@
 package com.jwt_auth_template.jwt;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Date;
 

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
@@ -2,8 +2,14 @@ package com.jwt_auth_template.jwt;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Date;
+
 public interface RefreshTokenRepository
         extends JpaRepository<RefreshTokenEntity, Long> {
 
     int deleteByMemberIdentifier(String memberIdentifier);
+
+    int deleteByRefreshToken(String refreshToken);
+
+    RefreshTokenEntity findByRefreshToken(String refreshToken);
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/CustomUserDetails.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/CustomUserDetails.java
@@ -32,6 +32,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public String getUsername() {
         return member.getId().toString();
+        //return member.getMemberIdentifier();
     }
 
     @Override

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
     void init() {
         var requestMatcher =
                 PathPatternRequestMatcher.withDefaults().basePath("/");
+
         permitAllRequestMatcher = new OrRequestMatcher(
                 requestMatcher.matcher(HttpMethod.GET, "/swagger-ui/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/v3/api-docs/**"),

--- a/jwt_auth_template/src/main/resources/application.properties
+++ b/jwt_auth_template/src/main/resources/application.properties
@@ -14,5 +14,5 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 ##
 
 jwt.secret-key=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD
-jwt.access-token-exptime=20s
-jwt.refresh-token-exptime=30d
+jwt.access-token-exptime=1d
+jwt.refresh-token-exptime=30s

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/jwt/RefreshTokenRepositoryTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/jwt/RefreshTokenRepositoryTest.java
@@ -16,9 +16,12 @@ class RefreshTokenRepositoryTest {
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
 
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
     @Test
     void setAndGetRefreshToken() {
-        RefreshTokenEntity refreshTokenEntity = RefreshTokenEntity.createRefreshToken(
+        RefreshTokenEntity refreshTokenEntity = jwtTokenUtil.generateRefreshTokenEntity(
                 "323",
                 "afsdasdf",
                 new Date()


### PR DESCRIPTION
#8 
#9 
#10 
목표

access 만료를 refresh로 복구하고, 로그아웃 시 refresh를 폐기한다.

TODO

/auth/refresh 구현: refresh 검증 → DB 조회 → 새 access 발급
완료.
(선택) 로테이션 정책 적용: 기존 refresh 폐기 + 새 refresh 저장
로테이션 적용. 기존 폐기, 새로 발급.
/auth/logout 구현: refresh 폐기(단일 디바이스/전체 정책에 맞게)
단일디바이스.
refresh 저장값 해시 저장 여부 결정
해시 저장 안함.
완료 조건 (DoD)

refresh로 access 재발급 가능
확인.
logout 후 refresh 재사용 불가
확인.

목표

인증/인가/토큰/외부인증 실패를 전부 “일관된 JSON 에러”로 반환한다.

TODO

AuthenticationEntryPoint로 401 JSON 응답 통일
전 이슈에서 완료.
AccessDeniedHandler로 403 JSON 응답 통일
전 이슈에서 완료.
@RestControllerAdvice로 도메인 예외 공통 처리
전 이슈에서 완료.
에러 코드/메시지/traceId 포함 규칙 적용
전 이슈에서 완료.
필터 레벨 예외와 컨트롤러 레벨 예외 응답 포맷 일치시키기
전 이슈에서 완료.
완료 조건 (DoD)

모든 실패 케이스가 동일한 포맷(JSON)으로 내려온다
전 이슈에서 확인.
“JWT 오류 / 인증 실패 / 인가 실패”가 구분된다
전 이슈에서 확인.

JWT 단위 테스트(만료/서명/클레임)
확인.
CustomUserDetailsService 테스트(유저 상태/권한/예외)
확인.
필터/시큐리티 통합 테스트(401/403/정상)
확인.
auth API 테스트(join/login/refresh/logout)
확인.