### PR TITLE
Feat/last

### DIFF
--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthController.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthController.java
@@ -26,7 +26,7 @@ public class AuthController {
         Member member = authService.joinWithKakao(joinWithKakaoRequestDto);
 
         String accessToken =
-                authService.enrollNewAuthTokens(member.getId().toString(), response,new Date());
+                authService.enrollNewAuthTokens(member, response);
 
         return ResponseEntity.ok(
                 ApiResponse.ok(new LoginSuccessResponseDto(accessToken))
@@ -45,7 +45,7 @@ public class AuthController {
         );
 
         String accessToken =
-                authService.enrollNewAuthTokens(member.getId().toString(), response,new Date());
+                authService.enrollNewAuthTokens(member, response);
 
         return ResponseEntity.ok(
                 ApiResponse.ok(new LoginSuccessResponseDto(accessToken))

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
@@ -44,6 +44,7 @@ public class AuthService {
         return memberService.save(member);
     }
 
+
     public String enrollNewAuthTokens(Member member,HttpServletResponse response) {
         return upsertNewAuthTokens(member.getMemberIdentifier(),response,new Date());
     }
@@ -55,11 +56,14 @@ public class AuthService {
         RefreshTokenEntity refreshTokenEntity =
                 jwtTokenUtil.generateRefreshTokenEntity(memberIdentifier, refreshToken);
 
+
+        jwtTokenUtil.generateCookieRefreshToken(refreshToken, response);
+
         jwtTokenUtil.upsertRefreshTokenEntity(refreshTokenEntity);
-        jwtTokenUtil.generateCookieRefreshToken(refreshTokenEntity, response);
 
         return accessToken;
     }
+
 
     public Member findMemberWithOauthToken(String oauthToken, AuthType authType) {
 
@@ -75,6 +79,7 @@ public class AuthService {
 
         return memberService.getActiveOAuthMember(oauthMemberInfo);
     }
+
 
     public String reissueAccessToken(String refreshToken, HttpServletResponse response) {
 

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
@@ -53,7 +53,7 @@ public class AuthService {
         String refreshToken = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, issuedAt, memberIdentifier);
 
         RefreshTokenEntity refreshTokenEntity =
-                jwtTokenUtil.generateRefreshTokenEntity(memberIdentifier, refreshToken, issuedAt);
+                jwtTokenUtil.generateRefreshTokenEntity(memberIdentifier, refreshToken);
 
         jwtTokenUtil.upsertRefreshTokenEntity(refreshTokenEntity);
         jwtTokenUtil.generateCookieRefreshToken(refreshTokenEntity, response);
@@ -83,7 +83,7 @@ public class AuthService {
             //검증과 식별자 추출
             String memberIdentifier = jwtTokenUtil.getMemberIdentifier(refreshToken);
 
-            return  upsertNewAuthTokens(memberIdentifier, response, refreshTokenEntity.getIssuedAt());
+            return  upsertNewAuthTokens(memberIdentifier, response, jwtTokenUtil.getIssuedAt(refreshToken));
         } catch (JwtValidAuthenticationException e) {
 
             switch (e.getErrorCode()) {

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/auth/AuthService.java
@@ -44,7 +44,11 @@ public class AuthService {
         return memberService.save(member);
     }
 
-    public String enrollNewAuthTokens(String memberIdentifier, HttpServletResponse response, Date issuedAt) {
+    public String enrollNewAuthTokens(Member member,HttpServletResponse response) {
+        return upsertNewAuthTokens(member.getMemberIdentifier(),response,new Date());
+    }
+
+    private String upsertNewAuthTokens(String memberIdentifier, HttpServletResponse response, Date issuedAt) {
         String accessToken = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, issuedAt, memberIdentifier);
         String refreshToken = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, issuedAt, memberIdentifier);
 
@@ -79,7 +83,7 @@ public class AuthService {
             //검증과 식별자 추출
             String memberIdentifier = jwtTokenUtil.getMemberIdentifier(refreshToken);
 
-            return  enrollNewAuthTokens(memberIdentifier, response, refreshTokenEntity.getIssuedAt());
+            return  upsertNewAuthTokens(memberIdentifier, response, refreshTokenEntity.getIssuedAt());
         } catch (JwtValidAuthenticationException e) {
 
             switch (e.getErrorCode()) {

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/AuthGlobalExceptionHandler.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/AuthGlobalExceptionHandler.java
@@ -20,8 +20,8 @@ public class AuthGlobalExceptionHandler {
         return buildErrorResponse(exception.getErrorCode());
     }
 
-    @ExceptionHandler(MemberException.class)
-    public ResponseEntity<ApiResponse<Void>> handleMemberException(final MemberException exception) {
+    @ExceptionHandler(MemberAuthenticationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMemberException(final MemberAuthenticationException exception) {
         return buildErrorResponse(exception.getErrorCode());
     }
 

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/CustomAuthenticationEntryPoint.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/CustomAuthenticationEntryPoint.java
@@ -48,6 +48,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         if (ex instanceof JwtValidAuthenticationException jwtEx) {
             return jwtEx.getErrorCode();
         }
+        if(ex instanceof  MemberAuthenticationException memberEx) {
+            return memberEx.getErrorCode();
+        }
 
         // 3) 토큰이 아예 없거나(익명 접근) 등으로 발생하는 대표 케이스
         if (ex instanceof InsufficientAuthenticationException) {

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/ErrorCode.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/ErrorCode.java
@@ -23,7 +23,7 @@ public enum ErrorCode {
     UNAUTHENTICATED("SEC-001", HttpStatus.UNAUTHORIZED, "Unauthenticated"),
     UNAUTHORIZED("SEC-002", HttpStatus.FORBIDDEN, "Unauthorized"),
     MEMBER_DUPLICATE("SEC-003", HttpStatus.INTERNAL_SERVER_ERROR, "Duplicate Member"),
-    MEMBER_NOTFOUND("SEC-004", HttpStatus.INTERNAL_SERVER_ERROR, "Member Not Found"),
+    MEMBER_NOTFOUND("SEC-004", HttpStatus.INTERNAL_SERVER_ERROR, "Member Not Exists"),
 
     OAUTH_RESOURCE_ERROR("OAUTH-001", HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Unavailable");
 

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/MemberAuthenticationException.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/MemberAuthenticationException.java
@@ -1,0 +1,14 @@
+package com.jwt_auth_template.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class MemberAuthenticationException extends AuthenticationException {
+    private final ErrorCode errorCode;
+
+    public MemberAuthenticationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/MemberException.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/exception/MemberException.java
@@ -1,8 +1,0 @@
-package com.jwt_auth_template.exception;
-
-public class MemberException extends ApiException{
-
-    public MemberException(ErrorCode errorCode) {
-        super(errorCode);
-    }
-}

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtProperties.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtProperties.java
@@ -13,6 +13,9 @@ public class JwtProperties {
     @Value("${jwt.secret-key}")
     private String secretKey;
 
+    @Value("${jwt.secret-key.refresh-token}")
+    private String refreshTokenSecretKey;
+
     @Value("${jwt.access-token-exptime}")
     @Getter(AccessLevel.NONE)
     private Duration accessTokenExpiration;

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
@@ -56,18 +56,12 @@ public class JwtTokenUtil {
     }
 
     public RefreshTokenEntity generateRefreshTokenEntity(
-            String memberIdentifier, String refreshToken, Date issuedAt
+            String memberIdentifier, String refreshToken
     ) {
-        Date expDate = new Date(
-                issuedAt.getTime() +
-                        jwtProperties.getRefreshTokenTime()
-        );
 
         return RefreshTokenEntity.createRefreshToken(
                 memberIdentifier,
-                refreshToken,
-                issuedAt,
-                expDate
+                refreshToken
         );
     }
 
@@ -90,10 +84,11 @@ public class JwtTokenUtil {
     }
 
     public void generateCookieRefreshToken(RefreshTokenEntity refreshTokenEntity, HttpServletResponse response) {
-        Cookie cookie = new Cookie("refreshToken", refreshTokenEntity.getRefreshToken());
+        String refreshToken = refreshTokenEntity.getRefreshToken();
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-        int age = (int) ((new Date()).getTime() - refreshTokenEntity.getExpiresAt().getTime() / 1000);
+        int age = (int) ((new Date()).getTime() - getExpiresAt(refreshToken).getTime() / 1000);
         cookie.setMaxAge(age);
         response.addCookie(cookie);
     }
@@ -126,6 +121,16 @@ public class JwtTokenUtil {
     public String getMemberIdentifier(String jwtToken) {
         return getClaimsFromJwtToken(jwtToken)
                 .getSubject();
+    }
+
+    public Date getIssuedAt(String jwtToken) {
+        return getClaimsFromJwtToken(jwtToken)
+                .getIssuedAt();
+    }
+
+    public Date getExpiresAt(String jwtToken) {
+        return getClaimsFromJwtToken(jwtToken)
+                .getExpiration();
     }
 
     private Claims getClaimsFromJwtToken(String jwtToken) {

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/JwtTokenUtil.java
@@ -124,7 +124,6 @@ public class JwtTokenUtil {
     }
 
     public String getMemberIdentifier(String jwtToken) {
-
         return getClaimsFromJwtToken(jwtToken)
                 .getSubject();
     }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
@@ -5,8 +5,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Date;
-
 @Entity
 @Getter
 @Setter
@@ -21,16 +19,16 @@ public class RefreshTokenEntity {
     @Column(nullable = false,unique = true,updatable = false)
     private String memberIdentifier;
 
-    @Column(nullable = false)
-    private String refreshToken;
+    @Column(nullable = false,unique = true, updatable = false)
+    private String hashedRefreshToken;
 
     public static RefreshTokenEntity createRefreshToken(
             String memberIdentifier,
-            String refreshToken
+            String hashedRefreshToken
     ) {
         RefreshTokenEntity token = new RefreshTokenEntity();
         token.setMemberIdentifier(memberIdentifier);
-        token.setRefreshToken(refreshToken);
+        token.setHashedRefreshToken(hashedRefreshToken);
 
         return token;
     }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenEntity.java
@@ -24,23 +24,14 @@ public class RefreshTokenEntity {
     @Column(nullable = false)
     private String refreshToken;
 
-    @Column(nullable = false)
-    private Date issuedAt;
-
-    @Column(nullable = false)
-    private Date expiresAt;
-
     public static RefreshTokenEntity createRefreshToken(
             String memberIdentifier,
-            String refreshToken,
-            Date issuedAt,
-            Date expiresAt
+            String refreshToken
     ) {
         RefreshTokenEntity token = new RefreshTokenEntity();
         token.setMemberIdentifier(memberIdentifier);
         token.setRefreshToken(refreshToken);
-        token.setIssuedAt(issuedAt);
-        token.setExpiresAt(expiresAt);
+
         return token;
     }
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/jwt/RefreshTokenRepository.java
@@ -1,15 +1,11 @@
 package com.jwt_auth_template.jwt;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.Date;
 
 public interface RefreshTokenRepository
         extends JpaRepository<RefreshTokenEntity, Long> {
 
     int deleteByMemberIdentifier(String memberIdentifier);
 
-    RefreshTokenEntity findByRefreshToken(String refreshToken);
+    RefreshTokenEntity findByHashedRefreshToken(String refreshToken);
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/Member.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/Member.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.UUID;
+
 @Entity
 @Getter
 @Setter
@@ -15,6 +17,10 @@ public class Member {
     @Column(name = "member_id")
     @Setter(AccessLevel.NONE)
     private Long id;
+
+    @Column(nullable = false,unique = true,updatable = false)
+    @Setter(AccessLevel.PRIVATE)
+    private String memberIdentifier;
 
     @Column(nullable = false)
     private boolean active;
@@ -52,6 +58,7 @@ public class Member {
         member.setAuthType(authType);
         member.setOauthId(oauthId);
         member.setPassword(password);
+        member.setMemberIdentifier(UUID.randomUUID().toString());
         return member;
     }
 }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberRepository.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByMemberIdentifier(String memberIdentifier);
+
     @Query("update Member m set m.active = :active where m.id = :id")
     @Modifying
     int updateActiveById(boolean active, Long id);

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberService.java
@@ -33,8 +33,8 @@ public class MemberService {
         }
     }
 
-    public Member getActiveMember(Long id) {
-        Member member = memberRepository.findById(id)
+    public Member getActiveMemberByMemberIdentifier(String memberIdentifier) {
+        Member member = memberRepository.findByMemberIdentifier(memberIdentifier)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOTFOUND));
 
         if (!member.isActive()) {

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/member/MemberService.java
@@ -2,7 +2,7 @@ package com.jwt_auth_template.member;
 
 import com.jwt_auth_template.auth.dto.OAuthMemberInfo;
 import com.jwt_auth_template.exception.ErrorCode;
-import com.jwt_auth_template.exception.MemberException;
+import com.jwt_auth_template.exception.MemberAuthenticationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,18 +29,8 @@ public class MemberService {
         };
 
         if (findMember.isPresent()) {
-            throw new MemberException(ErrorCode.MEMBER_DUPLICATE);
+            throw new MemberAuthenticationException(ErrorCode.MEMBER_DUPLICATE);
         }
-    }
-
-    public Member getActiveMemberByMemberIdentifier(String memberIdentifier) {
-        Member member = memberRepository.findByMemberIdentifier(memberIdentifier)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOTFOUND));
-
-        if (!member.isActive()) {
-            throw new MemberException(ErrorCode.MEMBER_NOTFOUND);
-        }
-        return member;
     }
 
     public Member getActiveOAuthMember(OAuthMemberInfo oAuthMemberInfo) {
@@ -50,10 +40,10 @@ public class MemberService {
                                 oAuthMemberInfo.getName(),
                                 oAuthMemberInfo.getAuthType()
                         )
-                        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOTFOUND));
+                        .orElseThrow(() -> new MemberAuthenticationException(ErrorCode.MEMBER_NOTFOUND));
 
         if (!member.isActive()) {
-            throw new MemberException(ErrorCode.MEMBER_NOTFOUND);
+            throw new MemberAuthenticationException(ErrorCode.MEMBER_NOTFOUND);
         }
         return member;
     }

--- a/jwt_auth_template/src/main/java/com/jwt_auth_template/security/CustomUserDetailsService.java
+++ b/jwt_auth_template/src/main/java/com/jwt_auth_template/security/CustomUserDetailsService.java
@@ -18,7 +18,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String memberIdentifier) throws UsernameNotFoundException {
         Member activeMember =
-                memberService.getActiveMember(Long.parseLong(memberIdentifier));
+                memberService.getActiveMemberByMemberIdentifier(memberIdentifier);
         return new CustomUserDetails(activeMember);
     }
 }

--- a/jwt_auth_template/src/main/resources/application.properties
+++ b/jwt_auth_template/src/main/resources/application.properties
@@ -14,5 +14,5 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 ##
 
 jwt.secret-key=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD
-jwt.access-token-exptime=1d
-jwt.refresh-token-exptime=30s
+jwt.access-token-exptime=8h
+jwt.refresh-token-exptime=1d

--- a/jwt_auth_template/src/main/resources/application.properties
+++ b/jwt_auth_template/src/main/resources/application.properties
@@ -14,5 +14,6 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 ##
 
 jwt.secret-key=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD
+jwt.secret-key.refresh-token=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD
 jwt.access-token-exptime=8h
 jwt.refresh-token-exptime=1d

--- a/jwt_auth_template/src/test/java/com/jwt_auth_template/security/jwt/JwtTokenUtilTest.java
+++ b/jwt_auth_template/src/test/java/com/jwt_auth_template/security/jwt/JwtTokenUtilTest.java
@@ -70,7 +70,7 @@ class JwtTokenUtilTest {
 
         RefreshTokenEntity saved = captor.getValue();
         Assertions.assertThat(saved.getMemberIdentifier()).isEqualTo(memberIdentifier);
-        Assertions.assertThat(saved.getRefreshToken()).isEqualTo(token);
+        Assertions.assertThat(saved.getHashedRefreshToken()).isEqualTo(token);
         Assertions.assertThat(saved.getExpiresAt()).isNotNull();
     }
 


### PR DESCRIPTION
#17 
이메일 인증 과정 추가,
=> 관련 필터 허용 경로 지정
=> 프로젝트에서 안하기로 결정

refresh token rotation,
=>케이스별로 처리
=> 이전 이슈에서 완료.

이중 ID
=>다른 비순차적 식별자부여, 식별자 노출 안되게 하는 방법을 생각해보자.
=>authentication과 authorization에 대해서만 사용.
나머지는 원래 멤버 ID 활용.->SecurityContext에 저장할 principal에 auth식별자가 아닌 멤버ID.
정리 : 책임분리. auth식별자는 auth에서만. 나머지 케이스는 멤버 ID 활용.

refresh token 원문 db에 저장->보안 취약성.
jwt id와 auth 식별자 활용으로 refresh token 길이 불필요하게 길어짐.
db저장시 hash 적용.
중복되는 refresh token 엔티티의 iat expt는 필드에서 지우고 필요할 때 추출하는 방식으로 변경.
서브젝트를 가져올 때 오버헤드가 크려나..? 크면 원래 필드 복구.

가입시
멤버 중복 검증 + 멤버 저장 + 로그인 과정


로그인시
억세스토큰, 리프레시토큰 모두 재발급, 기존 것들 DB,쿠키 삭제


리이슈시
정상적으로 억세스토큰 재발급=>기존 리프레시 DB 삭제, 리프레시 재발급
리프레시 토큰 이상함 => jwt reissue exception 
전에 쓰던 리프레시 토큰 
=> 만료처리 예외 + replay attack 방지(멤버 관련 리프레시 DB 모두 삭제)


로그아웃 시
멤버 관련 리프레시 토큰 DB,쿠키에서 모두 삭제.